### PR TITLE
fix: event duration

### DIFF
--- a/src/app/company/welcome/date-en.pipe.ts
+++ b/src/app/company/welcome/date-en.pipe.ts
@@ -33,10 +33,9 @@ export class DateEnPipe implements PipeTransform {
       return `${startMonth} ${startDay}${startTerm} `;
     }
 
-    const endDate = new Date(start.getTime() + end.getTime());
 
-    const endDay = endDate.getDate();
-    const endMonth = this.translator[endDate.getMonth()];
+    const endDay = end.getDate();
+    const endMonth = this.translator[end.getMonth()];
 
     var endTerm
     if(endDay === 1 || endDay === 21 || endDay === 31){

--- a/src/app/company/welcome/date-pt.pipe.ts
+++ b/src/app/company/welcome/date-pt.pipe.ts
@@ -19,10 +19,8 @@ export class DatePtPipe implements PipeTransform {
       return `${startDay} de ${startMonth}`;
     }
 
-    const endDate = new Date(start.getTime() + end.getTime());
-
-    const endDay = endDate.getDate();
-    const endMonth = this.translator[endDate.getMonth()];
+    const endDay = end.getDate();
+    const endMonth = this.translator[end.getMonth()];
 
     return start.getMonth() === end.getMonth()
       ? `${startDay} a ${endDay} de ${startMonth}`

--- a/src/app/company/welcome/welcome.component.html
+++ b/src/app/company/welcome/welcome.component.html
@@ -14,7 +14,7 @@
 
           <p>
             <span [innerHTML]="'page0.text.p2' | translate"></span>
-            <span> {{english ? (event.begin | dateEn: event.duration) : (event.begin | datePt: event.duration) }}</span>
+            <span> {{english ? (event.begin | dateEn: event.end) : (event.begin | datePt: event.end) }}</span>
           </p>
 
           <p>

--- a/src/app/deck/event.ts
+++ b/src/app/deck/event.ts
@@ -28,6 +28,6 @@ export class Event {
     getDuration(): number {
         const beginDate = new Date(this.begin).getTime()
         const endDate = new Date(this.end).getTime()
-        return new Date(endDate - beginDate).getUTCDate() - 1
+        return new Date(endDate - beginDate).getUTCDate()
     }
 }


### PR DESCRIPTION
This MR fixes the welcome text to show the correct SINFO date and calculate the right event duration.

But to fix the event duration, the backend must also be changed. This [line](https://github.com/sinfo/corlief/blob/d9de585129bf55a29c48d627beea6b1735494708/helpers/pre.js#L40) must also be modified to `return new Date(endDate - beginDate).getUTCDate()`

Closes #106 